### PR TITLE
Add the global `node_modules` path to `NODE_PATH`

### DIFF
--- a/libexec/ndenv-exec
+++ b/libexec/ndenv-exec
@@ -43,5 +43,6 @@ done
 shift 1
 if [ "$NDENV_VERSION" != "system" ]; then
   export PATH="${NDENV_BIN_PATH}:${PATH}"
+  export NODE_PATH="${NDENV_ROOT}/versions/$(ndenv-version-name)/lib/node_modules:${NODE_PATH}"
 fi
 exec -a "$NDENV_COMMAND" "$NDENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
In Ruby or Python for example, we can `require` gems or `import` packages which have been installed globally. Even with rbenv/pyenv, no config required.

In Node however, we have to add manually the global `node_modules` path to `NODE_PATH`. It needs to be changed frequently in ndenv environment.

With this commit the global `node_modules` each version has will be added automatically just before execution in `ndenv-exec`.
