### PR TITLE
Always add /shims to PATH, even when creating duplicates

### DIFF
--- a/libexec/ndenv-init
+++ b/libexec/ndenv-init
@@ -79,9 +79,9 @@ fi
 
 mkdir -p "${NDENV_ROOT}/"{shims,versions}
 
-if [[ ":${PATH}:" != *:"${NDENV_ROOT}/shims":* ]]; then
-  echo 'export PATH="'${NDENV_ROOT}'/shims:${PATH}"'
-fi
+# Don't check to see if it is already included. This can cause problems
+# when reentering a shell (ie, via screen or tmux).
+echo 'export PATH="'${NDENV_ROOT}'/shims:${PATH}"'
 
 case "$shell" in
 bash | zsh )


### PR DESCRIPTION
ndenv-init currently checks to see if ndenv/shims is in $PATH and skips
adding it if so. This can create  issues when we re-enter a shell (ie,
using screen or tmux). Always adding ndev/shim to the path is consistent
with other *env tools.