### PR TITLE
Change the way to get the name of the current shell

### DIFF
--- a/libexec/ndenv-init
+++ b/libexec/ndenv-init
@@ -22,7 +22,11 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(basename "$SHELL")"
+  shell="$(ps c -p "$PPID" -o 'ucomm=' 2>/dev/null || true)"
+  shell="${shell##-}"
+  shell="${shell%% *}"
+  shell="${shell:-$SHELL}"
+  shell="${shell##*/}"
 fi
 
 READLINK=$(type -p greadlink readlink | head -1)


### PR DESCRIPTION
The current way to get the name of the using shell doesn't work in some situations.

My default shell is bash, but I use zsh on tmux and then `ndenv-init call` campletions `completions/ndenv.bash` in zsh on tmux.

Now, rbenv use the different way to get the shell's name.
https://github.com/sstephenson/rbenv/blob/master/libexec/rbenv-init#L23