### PR TITLE
add ndenv.fish inspired rbenv.fish, pyenv.fish

### DIFF
--- a/completions/ndenv.fish
+++ b/completions/ndenv.fish
@@ -1,0 +1,24 @@
+function __fish_ndenv_needs_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -eq 1 -a $cmd[1] = 'ndenv' ]
+    return 0
+  end
+  return 1
+end
+
+function __fish_ndenv_using_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -gt 1 ]
+    if [ $argv[1] = $cmd[2] ]
+      return 0
+    end
+  end
+  return 1
+end
+
+complete -f -c ndenv -n '__fish_ndenv_needs_command' -a '(ndenv commands)'
+for cmd in (ndenv commands)
+  complete -f -c ndenv -n "__fish_ndenv_using_command $cmd" -a \
+    "(ndenv completions (commandline -opc)[2..-1])"
+end
+

--- a/libexec/ndenv-init
+++ b/libexec/ndenv-init
@@ -149,8 +149,6 @@ esac
 if [ "$shell" != "fish" ]; then
 IFS="|"
 cat <<EOS
-ndenv() {
-  typeset command
   command="\$1"
   if [ "\$#" -gt 0 ]; then
     shift

--- a/libexec/ndenv-init
+++ b/libexec/ndenv-init
@@ -66,6 +66,9 @@ if [ -z "$print" ]; then
   ksh )
     profile='~/.profile'
     ;;
+  fish )
+    profile='~/.config/fish/config.fish'
+    ;;
   * )
     profile='your profile'
     ;;
@@ -74,7 +77,14 @@ if [ -z "$print" ]; then
   { echo "# Load ndenv automatically by adding"
     echo "# the following to ${profile}:"
     echo
-    echo 'eval "$(ndenv init -)"'
+    case "$shell" in
+    fish )
+      echo 'status --is-interactive; and source (ndenv init -|psub)'
+      ;;
+    * )
+      echo 'eval "$(ndenv init -)"'
+      ;;
+    esac
     echo
   } >&2
 
@@ -83,12 +93,21 @@ fi
 
 mkdir -p "${NDENV_ROOT}/"{shims,versions}
 
-if [[ ":${PATH}:" != *:"${NDENV_ROOT}/shims":* ]]; then
+case "$shell" in
+fish )
+  echo "set -gx PATH '${NDENV_ROOT}/shims' \$PATH"
+;;
+* )
+  if [[ ":${PATH}:" != *:"${NDENV_ROOT}/shims":* ]]; then
   echo 'export PATH="'${NDENV_ROOT}'/shims:${PATH}"'
 fi
+;;
+esac
+
+
 
 case "$shell" in
-bash | zsh )
+bash | zsh | fish)
   echo "source \"$root/completions/ndenv.${shell}\""
   ;;
 esac
@@ -98,6 +117,36 @@ if [ -z "$no_rehash" ]; then
 fi
 
 commands=(`ndenv-commands --sh`)
+case "$shell" in
+fish )
+  cat <<EOS
+function ndenv
+  set command \$argv[1]
+  set -e argv[1]
+  switch "\$command"
+  case ${commands[*]}
+    source (ndenv "sh-\$command" \$argv|psub)
+  case '*'
+    command ndenv "\$command" \$argv
+  end
+end
+EOS
+  ;;
+ksh )
+  cat <<EOS
+function ndenv {
+  typeset command
+EOS
+  ;;
+* )
+  cat <<EOS
+ndenv() {
+  local command
+EOS
+  ;;
+esac
+
+if [ "$shell" != "fish" ]; then
 IFS="|"
 cat <<EOS
 ndenv() {
@@ -115,3 +164,4 @@ ndenv() {
   esac
 }
 EOS
+fi


### PR DESCRIPTION
add ndenv.fish for fish user.

I copied almost code by rbenv.fish and pyenv.fish.

- rbenv.fish
```fish
function __fish_rbenv_needs_command
  set cmd (commandline -opc)
  if [ (count $cmd) -eq 1 -a $cmd[1] = 'rbenv' ]
    return 0
  end
  return 1
end

function __fish_rbenv_using_command
  set cmd (commandline -opc)
  if [ (count $cmd) -gt 1 ]
    if [ $argv[1] = $cmd[2] ]
      return 0
    end
  end
  return 1
end

complete -f -c rbenv -n '__fish_rbenv_needs_command' -a '(rbenv commands)'
for cmd in (rbenv commands)
  complete -f -c rbenv -n "__fish_rbenv_using_command $cmd" -a \
    "(rbenv completions (commandline -opc)[2..-1])"
end
```

- pyenv.fish
```fish
function __fish_pyenv_needs_command
  set cmd (commandline -opc)
  if [ (count $cmd) -eq 1 -a $cmd[1] = 'pyenv' ]
    return 0
  end
  return 1
end

function __fish_pyenv_using_command
  set cmd (commandline -opc)
  if [ (count $cmd) -gt 1 ]
    if [ $argv[1] = $cmd[2] ]
      return 0
    end
  end
  return 1
end

complete -f -c pyenv -n '__fish_pyenv_needs_command' -a '(pyenv commands)'
for cmd in (pyenv commands)
  complete -f -c pyenv -n "__fish_pyenv_using_command $cmd" -a \
    "(pyenv completions (commandline -opc)[2..-1])"
end
```